### PR TITLE
Can't configure jobs to run as SYSTEM

### DIFF
--- a/lib/win32/taskscheduler.rb
+++ b/lib/win32/taskscheduler.rb
@@ -487,7 +487,7 @@ module Win32
       setAccountInformation = Win32::API::Function.new(table[30],'PPP','L')
 
       if (user.nil? || user=="") && (password.nil? || password=="")
-        hr = setAccountInformation.call(@pITask, "", nil)
+        hr = setAccountInformation.call(@pITask, multi_to_wide(""), nil)
       else
         user = multi_to_wide(user)
         password = multi_to_wide(password)


### PR DESCRIPTION
When configuring a job to run as SYSTEM, the call to
set_account_information("", nil) would succeed, but the subsequent
call to save would fail with the error:

c:/ruby187/lib/ruby/gems/1.8/gems/win32-taskscheduler-0.2.0/lib/win32/taskscheduler.rb:376:in
`save': The operation completed successfully. (Win32::TaskScheduler::Error)

According to the MSDN documentation,
http://msdn.microsoft.com/en-us/library/windows/desktop/aa381276(v=VS.85).aspx

   To specify the local system account, use the empty string, L"". Do
   not use any other string to specify the local system account.

This commit changes the user parameter to be a wide empty string.
