### PR TITLE
FormatMessage FFI fixes

### DIFF
--- a/lib/win32/windows/helper.rb
+++ b/lib/win32/windows/helper.rb
@@ -45,7 +45,7 @@ module Windows
         error = match.captures.first.hex
         win_error(function, error)
       else
-        msg
+        "#{function}: #{err.to_s}"
       end
     end
   end


### PR DESCRIPTION
Fix a number of issues including
- FFI definitions for FormatMessage on x64
- FFI memory releasing block form for the 1024 byte buffer
- Security Issue with reading string buffer filled by FormatMessage
- Bug in fallback code path within ole_error
- Define readable constants for flags used in FormatMessage
