### PR TITLE
Added get_task and enabled? method

### DIFF
--- a/lib/win32/taskscheduler.rb
+++ b/lib/win32/taskscheduler.rb
@@ -333,6 +333,17 @@ module Win32
       enum.include?(task)
     end
 
+    def get_task(task)
+      raise TypeError unless task.is_a?(String)
+
+      begin
+        registeredTask = @root.GetTask(task)
+        @task = registeredTask
+      rescue WIN32OLERuntimeError => err
+        raise Error, ole_error('activate', err)
+      end
+    end
+
     # Activate the specified task.
     #
     def activate(task)
@@ -1079,6 +1090,11 @@ module Win32
       end
 
       status
+    end
+
+    def enabled?
+      check_for_active_task
+      @task.enabled
     end
 
     # Returns the exit code from the last scheduled run.


### PR DESCRIPTION
Added method get_task which will return existing task. And method to check whether task is enabled.

In library if we have to get the current task we have to use activate method. Which actually enables the task so to just to get existing task I have added get task method. 

`enabled?` method added to see if the given task is enabled or not.

Signed-off-by: vasu1105 <vasundhara.jagdale@msystechnologies.com>