### PR TITLE
Helper module to handle date time(in PT Format) related calculations

### DIFF
--- a/lib/win32/taskscheduler.rb
+++ b/lib/win32/taskscheduler.rb
@@ -656,57 +656,50 @@ module Win32
           tmp = {}
           tmp[:days_interval] = trig.DaysInterval
           trigger[:type] = tmp
-          trigger[:random_minutes_interval] = trig.RandomDelay.scan(/(\d+)M/)[0][0].to_i if trig.RandomDelay != ""
+          trigger[:random_minutes_interval] = time_in_minutes(trig.RandomDelay)
         when TASK_TIME_TRIGGER_WEEKLY
           tmp = {}
           tmp[:weeks_interval] = trig.WeeksInterval
           tmp[:days_of_week] = trig.DaysOfWeek
           trigger[:type] = tmp
-          trigger[:random_minutes_interval] = trig.RandomDelay.scan(/(\d+)M/)[0][0].to_i if trig.RandomDelay != ""
+          trigger[:random_minutes_interval] = time_in_minutes(trig.RandomDelay)
         when TASK_TIME_TRIGGER_MONTHLYDATE
           tmp = {}
           tmp[:months] = trig.MonthsOfYear
           tmp[:days] = trig.DaysOfMonth
           trigger[:type] = tmp
-          trigger[:random_minutes_interval] = trig.RandomDelay.scan(/(\d+)M/)[0][0].to_i if trig.RandomDelay != ""
+          trigger[:random_minutes_interval] = time_in_minutes(trig.RandomDelay)
         when TASK_TIME_TRIGGER_MONTHLYDOW
           tmp = {}
           tmp[:months] = trig.MonthsOfYear
           tmp[:days_of_week] = trig.DaysOfWeek
           tmp[:weeks_of_month] = trig.WeeksOfMonth
           trigger[:type] = tmp
-          trigger[:random_minutes_interval] = trig.RandomDelay.scan(/(\d+)M/)[0][0].to_i if trig.RandomDelay != ""
+          trigger[:random_minutes_interval] = time_in_minutes(trig.RandomDelay)
         when TASK_TIME_TRIGGER_ONCE
           tmp = {}
           tmp[:once] = nil
           trigger[:type] = tmp
-          trigger[:random_minutes_interval] = trig.RandomDelay.scan(/(\d+)M/)[0][0].to_i if trig.RandomDelay != ""
+          trigger[:random_minutes_interval] = time_in_minutes(trig.RandomDelay)
         when TASK_EVENT_TRIGGER_AT_SYSTEMSTART
-          trigger[:delay_duration] = trig.Delay.scan(/(\d+)M/)[0][0].to_i if trig.Delay != ""
+          trigger[:delay_duration] = time_in_minutes(trig.Delay)
         when TASK_EVENT_TRIGGER_AT_LOGON
           trigger[:user_id] = trig.UserId if trig.UserId.to_s != ""
-          trigger[:delay_duration] = trig.Delay.scan(/(\d+)M/)[0][0].to_i if trig.Delay != ""
+          trigger[:delay_duration] = time_in_minutes(trig.Delay)
         when TASK_EVENT_TRIGGER_ON_IDLE
-          trigger[:execution_time_limit] = trig.ExecutionTimeLimit
+          trigger[:execution_time_limit] = time_in_minutes(trig.ExecutionTimeLimit)
         else
           raise Error, 'Unknown trigger type'
       end
 
-      trigger[:start_year], trigger[:start_month],
-      trigger[:start_day],  trigger[:start_hour],
-      trigger[:start_minute] = trig.StartBoundary.scan(/(\d+)-(\d+)-(\d+)T(\d+):(\d+)/).first
+      trigger[:start_year], trigger[:start_month], trigger[:start_day],
+      trigger[:start_hour], trigger[:start_minute] = trig.StartBoundary.scan(/(\d+)-(\d+)-(\d+)T(\d+):(\d+)/).first
 
       trigger[:end_year], trigger[:end_month],
       trigger[:end_day] = trig.EndBoundary.scan(/(\d+)-(\d+)-(\d+)T/).first
 
-      if trig.Repetition.Duration != ""
-        trigger[:minutes_duration] = trig.Repetition.Duration.scan(/(\d+)M/)[0][0].to_i
-      end
-
-      if trig.Repetition.Interval != ""
-        trigger[:minutes_interval] = trig.Repetition.Interval.scan(/(\d+)M/)[0][0].to_i
-      end
-      
+      trigger[:minutes_duration] = time_in_minutes(trig.Repetition.Duration)
+      trigger[:minutes_interval] = time_in_minutes(trig.Repetition.Interval)
       trigger[:trigger_type] = trig.Type
 
       trigger
@@ -1266,7 +1259,28 @@ module Win32
       hash.each_with_object({}) do |(k, v), h|
         h[underscore(k.to_s).to_sym] = v.is_a?(Hash) ? symbolize_keys(v) : v 
       end
-    end    
+    end
+
+    # Will return total time in minutes
+    def time_in_minutes(time_str)
+      hour, min, sec = time_details(time_str)
+      ((hour.to_i * 60) + min.to_i + (sec.to_i / 60)) # may also use ceil if required
+    end
+
+    # will return an array of [hour, minute, seconds]
+    def time_details(time_str)
+      time_arr = []
+      # Will retrieve an array of arrays; each with a respective index position of
+      # [H, M, T] and rest will be nil.
+      # example: "PT2S10M4H" will return in
+      # [[nil, nil, "2"], [nil, "10", nil], ["4", nil, nil]]
+      splitted = time_str.scan(/(\d+)(?:H)|(\d+)(?:M)|(\d+)(?:S)/)
+      splitted.each do |arr|
+        i = arr.index{|x| !x.nil?}
+        time_arr[i] = arr[i]
+      end
+      time_arr
+    end
 
     def valid_trigger_option(trigger_type)
       [ TASK_TIME_TRIGGER_ONCE, TASK_TIME_TRIGGER_DAILY, TASK_TIME_TRIGGER_WEEKLY,

--- a/lib/win32/taskscheduler.rb
+++ b/lib/win32/taskscheduler.rb
@@ -1264,7 +1264,7 @@ module Win32
     # Will return total time in minutes
     def time_in_minutes(time_str)
       hour, min, sec = time_details(time_str)
-      ((hour.to_i * 60) + min.to_i + (sec.to_i / 60)) # may also use ceil if required
+      ((hour.to_i * 60) + min.to_i + (sec.to_i / 60)).to_s # may also use ceil if required
     end
 
     # will return an array of [hour, minute, seconds]

--- a/lib/win32/taskscheduler.rb
+++ b/lib/win32/taskscheduler.rb
@@ -733,7 +733,7 @@ module Win32
     def trigger=(trigger)
       raise TypeError unless trigger.is_a?(Hash)
       raise ArgumentError, 'Unknown trigger type' unless valid_trigger_option(trigger[:trigger_type])
-      
+
       check_for_active_task
 
       validate_trigger(trigger)
@@ -1218,7 +1218,7 @@ module Win32
       @task.Definition.Principal.ole_get_methods.each do |principal|
         principals_hash[principal.name] = @task.Definition.Principal._getproperty(principal.dispid, [], [])
       end
-      symbolize_keys(principals_hash)   
+      symbolize_keys(principals_hash)
     end
 
     # Returns a hash containing all settings of the current task
@@ -1342,7 +1342,6 @@ module Win32
         TASK_TIME_TRIGGER_MONTHLYDATE, TASK_TIME_TRIGGER_MONTHLYDOW, TASK_EVENT_TRIGGER_ON_IDLE,
         TASK_EVENT_TRIGGER_AT_SYSTEMSTART, TASK_EVENT_TRIGGER_AT_LOGON ].include?(trigger_type.to_i)
     end
-
 
     def validate_trigger(hash)
       [:start_year, :start_month, :start_day].each{ |key|

--- a/lib/win32/windows/time_calc_helper.rb
+++ b/lib/win32/windows/time_calc_helper.rb
@@ -21,38 +21,38 @@ module Windows
 
     # Calculates total time duration in seconds
     def time_in_seconds(time_str)
-      t = time_details(time_str)
+      dt_tm_hash = time_details(time_str)
       curr_time = Time.now
 
       # Basic time variables
-      y = curr_time.year + t[:year].to_i
-      mth = curr_time.month + t[:month].to_i
-      d = curr_time.day + t[:day].to_i
-      h = curr_time.hour + t[:hour].to_i
-      min = curr_time.min + t[:min].to_i
-      s = curr_time.sec + t[:sec].to_i
+      future_year = curr_time.year + dt_tm_hash[:year].to_i
+      future_mth = curr_time.month + dt_tm_hash[:month].to_i
+      future_day = curr_time.day + dt_tm_hash[:day].to_i
+      future_hr = curr_time.hour + dt_tm_hash[:hour].to_i
+      future_min = curr_time.min + dt_tm_hash[:min].to_i
+      future_sec = curr_time.sec + dt_tm_hash[:sec].to_i
 
       # 'extra value' calculations for these time variables
-      s, min = extra_time(s, min, 60)
-      min, h = extra_time(min, h, 60)
-      h, d = extra_time(h, d, 24)
+      future_sec, future_min = extra_time(future_sec, future_min, 60)
+      future_min, future_hr = extra_time(future_min, future_hr, 60)
+      future_hr, future_day = extra_time(future_hr, future_day, 24)
 
       # explicit method to calculate overloaded days;
       # They may stretch upto years; heance leap year & months are into consideration
-      d, mth, y = extra_days(d, mth, y, curr_time.month, curr_time.year)
+      future_day, future_mth, future_year = extra_days(future_day, future_mth, future_year, curr_time.month, curr_time.year)
 
-      mth, y = extra_time(mth, y, 12)
+      future_mth, future_year = extra_time(future_mth, future_year, 12)
 
-      future_time = Time.new(y, mth, d, h, min, s)
+      future_time = Time.new(future_year, future_mth, future_day, future_hr, future_min, future_sec)
 
       # Difference in time will return seconds
       future_time.to_i - curr_time.to_i
     end
 
-    # a will contain extra value in high_rank(eg min);
-    # b will hold actual low_rank(ie sec) Example:
+    # a will contain extra value of low_rank (in high_rank(eg min));
+    # b will hold actual low_rank value(ie sec) Example:
     # low_rank = 65, high_rank = 2, div_val = 60
-    # Hence a = 5; b = 1
+    # Hence a = 1; b = 5
     def extra_time(low_rank, high_rank, div_val)
       a, b = low_rank.divmod(div_val)
       high_rank += a; low_rank = b

--- a/lib/win32/windows/time_calc_helper.rb
+++ b/lib/win32/windows/time_calc_helper.rb
@@ -1,0 +1,116 @@
+module Windows
+  module TimeCalcHelper
+
+    DAY_OF_MONTH = [0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+
+    # Returns no of days in a given month of a year
+    def day_in_month(month, year)
+      (month == 2 && is_leap_year?(year)) ? 29 : DAY_OF_MONTH[month]
+    end
+
+    # Year is leap when it is a multiple of 4 and not a multiple of 100.
+    # But it can be a multiple of 400
+    def is_leap_year?(year)
+      (((year % 4).zero? && !(year % 100).zero?) || (year % 400).zero?)
+    end
+
+    # Returns total time duration in minutes
+    def time_in_minutes(time_str)
+      time_in_seconds(time_str) / 60
+    end
+
+    # Calculates total time duration in seconds
+    def time_in_seconds(time_str)
+      t = time_details(time_str)
+      curr_time = Time.now
+
+      # Basic time variables
+      y = curr_time.year + t[:year].to_i
+      mth = curr_time.month + t[:month].to_i
+      d = curr_time.day + t[:day].to_i
+      h = curr_time.hour + t[:hour].to_i
+      min = curr_time.min + t[:min].to_i
+      s = curr_time.sec + t[:sec].to_i
+
+      # 'extra value' calculations for these time variables
+      s, min = extra_time(s, min, 60)
+      min, h = extra_time(min, h, 60)
+      h, d = extra_time(h, d, 24)
+
+      # explicit method to calculate overloaded days;
+      # They may stretch upto years; heance leap year & months are into consideration
+      d, mth, y = extra_days(d, mth, y, curr_time.month, curr_time.year)
+
+      mth, y = extra_time(mth, y, 12)
+
+      future_time = Time.new(y, mth, d, h, min, s)
+
+      # Difference in time will return seconds
+      future_time.to_i - curr_time.to_i
+    end
+
+    # a will contain extra value in high_rank(eg min);
+    # b will hold actual low_rank(ie sec) Example:
+    # low_rank = 65, high_rank = 2, div_val = 60
+    # Hence a = 5; b = 1
+    def extra_time(low_rank, high_rank, div_val)
+      a, b = low_rank.divmod(div_val)
+      high_rank += a; low_rank = b
+      [low_rank, high_rank]
+    end
+
+    # Returns no of actual days with all overloaded months & Years
+    def extra_days(days_count, month_count, year_count, init_month, init_year)
+      # Will keep increamenting them with surplus days
+      days = days_count
+      mth = init_month
+      yr = init_year
+
+      loop do
+       days -= day_in_month(mth, yr)
+       break if days < 0
+       mth += 1
+       if mth > 12
+         mth = 1; yr += 1
+       end
+       days_count = days
+      end
+
+      # Setting actual incremented values
+      month_count += (mth - init_month)
+      year_count += (yr - init_year)
+
+      [days_count, month_count, year_count]
+    end
+
+    # Extracts "P_Y_M_DT_H_M_S" format and
+    # Returns a hash with applicable values of
+    # (keys =>) [:year, :month, :day, :hour, :min, :sec]
+    # Example: "PT3S" => {sec: 3}
+    def time_details(time_str)
+      tm_detail = {}
+      if time_str.to_s != ''
+        # time_str will be like "PxxYxxMxxDTxxHxxMxxS"
+        # Ignoring 'P' and extracting date and time
+        dt, tm = time_str[1..-1].split('T')
+
+        # Replacing strings
+        if dt.to_s != ''
+          dt['Y'] = 'year' if dt['Y']; dt['M'] = 'month' if dt['M']; dt['D'] = 'day' if dt['D']
+          dt_tm_array_to_hash(dt, tm_detail)
+        end
+
+        if tm.to_s != ''
+          tm['H'] = 'hour' if tm['H']; tm['M'] = 'min' if tm['M']; tm['S'] = 'sec' if tm['S']
+          dt_tm_array_to_hash(tm, tm_detail)
+        end
+      end
+      tm_detail
+    end
+
+    # Method to convert date/time array to hash
+    def dt_tm_array_to_hash(arr, tm_detail)
+      arr.split(/(\d+)/)[1..-1].each_slice(2).inject(tm_detail) { |h, i| h[i.last.to_sym] = i.first; h }
+    end
+  end
+end


### PR DESCRIPTION
Functionalities to convert date time (in PT format) in total minutes/seconds.
eg, when time_str = PT1M60S it will be either 2 mins OR 120 seconds in total.
time_in_minutes(time_str) OR time_in_seconds(time_str) will give this result
This may stretch up to hours/days/months even years

When user inserts some random time interval during creating/updating a task (say in minutes; (65)) ,then while retrieving trigger information, windows returns PT1M5S. Hence, he must be able to check this result as 65 mins again.
Signed-off-by: Nimesh Patni <nimesh.patni@msystechnologies.com>