### PR TITLE
Functionalities to convert date time (in PT format) in total minutes/seconds

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gemspec

--- a/lib/win32/windows/time_calc_helper.rb
+++ b/lib/win32/windows/time_calc_helper.rb
@@ -1,6 +1,10 @@
 module Windows
   module TimeCalcHelper
 
+    # Returns actual no of days for given month;
+    # Array with a 0 is defined to give actual result without
+    # any manipulation. eg, DAY_OF_MONTH[1] = 31
+    # 0(NUMBER) is kept to avoid exceptions during calculations
     DAY_OF_MONTH = [0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
 
     # Returns no of days in a given month of a year
@@ -26,7 +30,7 @@ module Windows
 
       # Basic time variables
       future_year = curr_time.year + dt_tm_hash[:year].to_i
-      future_mth = curr_time.month + dt_tm_hash[:month].to_i
+      future_month = curr_time.month + dt_tm_hash[:month].to_i
       future_day = curr_time.day + dt_tm_hash[:day].to_i
       future_hr = curr_time.hour + dt_tm_hash[:hour].to_i
       future_min = curr_time.min + dt_tm_hash[:min].to_i
@@ -39,11 +43,11 @@ module Windows
 
       # explicit method to calculate overloaded days;
       # They may stretch upto years; heance leap year & months are into consideration
-      future_day, future_mth, future_year = extra_days(future_day, future_mth, future_year, curr_time.month, curr_time.year)
+      future_day, future_month, future_year = extra_days(future_day, future_month, future_year, curr_time.month, curr_time.year)
 
-      future_mth, future_year = extra_time(future_mth, future_year, 12)
+      future_month, future_year = extra_time(future_month, future_year, 12)
 
-      future_time = Time.new(future_year, future_mth, future_day, future_hr, future_min, future_sec)
+      future_time = Time.new(future_year, future_month, future_day, future_hr, future_min, future_sec)
 
       # Difference in time will return seconds
       future_time.to_i - curr_time.to_i

--- a/lib/win32/windows/time_calc_helper.rb
+++ b/lib/win32/windows/time_calc_helper.rb
@@ -1,0 +1,116 @@
+module Windows
+  module TimeCalcHelper
+
+    DAY_OF_MONTH = [0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+
+    # Returns no of days in a given month of a year
+    def day_in_month(month, year)
+      (month == 2 && is_leap_year?(year)) ? 29 : DAY_OF_MONTH[month]
+    end
+
+    # Year is leap when it is a multiple of 4 and not a multiple of 100.
+    # But it can be a multiple of 400
+    def is_leap_year?(year)
+      (((year % 4).zero? && !(year % 100).zero?) || (year % 400).zero?)
+    end
+
+    # Returns total time duration in minutes
+    def time_in_minutes(time_str)
+      time_in_seconds(time_str) / 60
+    end
+
+    # Calculates total time duration in seconds
+    def time_in_seconds(time_str)
+      dt_tm_hash = time_details(time_str)
+      curr_time = Time.now
+
+      # Basic time variables
+      future_year = curr_time.year + dt_tm_hash[:year].to_i
+      future_mth = curr_time.month + dt_tm_hash[:month].to_i
+      future_day = curr_time.day + dt_tm_hash[:day].to_i
+      future_hr = curr_time.hour + dt_tm_hash[:hour].to_i
+      future_min = curr_time.min + dt_tm_hash[:min].to_i
+      future_sec = curr_time.sec + dt_tm_hash[:sec].to_i
+
+      # 'extra value' calculations for these time variables
+      future_sec, future_min = extra_time(future_sec, future_min, 60)
+      future_min, future_hr = extra_time(future_min, future_hr, 60)
+      future_hr, future_day = extra_time(future_hr, future_day, 24)
+
+      # explicit method to calculate overloaded days;
+      # They may stretch upto years; heance leap year & months are into consideration
+      future_day, future_mth, future_year = extra_days(future_day, future_mth, future_year, curr_time.month, curr_time.year)
+
+      future_mth, future_year = extra_time(future_mth, future_year, 12)
+
+      future_time = Time.new(future_year, future_mth, future_day, future_hr, future_min, future_sec)
+
+      # Difference in time will return seconds
+      future_time.to_i - curr_time.to_i
+    end
+
+    # a will contain extra value of low_rank (in high_rank(eg min));
+    # b will hold actual low_rank value(ie sec) Example:
+    # low_rank = 65, high_rank = 2, div_val = 60
+    # Hence a = 1; b = 5
+    def extra_time(low_rank, high_rank, div_val)
+      a, b = low_rank.divmod(div_val)
+      high_rank += a; low_rank = b
+      [low_rank, high_rank]
+    end
+
+    # Returns no of actual days with all overloaded months & Years
+    def extra_days(days_count, month_count, year_count, init_month, init_year)
+      # Will keep increamenting them with surplus days
+      days = days_count
+      mth = init_month
+      yr = init_year
+
+      loop do
+       days -= day_in_month(mth, yr)
+       break if days < 0
+       mth += 1
+       if mth > 12
+         mth = 1; yr += 1
+       end
+       days_count = days
+      end
+
+      # Setting actual incremented values
+      month_count += (mth - init_month)
+      year_count += (yr - init_year)
+
+      [days_count, month_count, year_count]
+    end
+
+    # Extracts "P_Y_M_DT_H_M_S" format and
+    # Returns a hash with applicable values of
+    # (keys =>) [:year, :month, :day, :hour, :min, :sec]
+    # Example: "PT3S" => {sec: 3}
+    def time_details(time_str)
+      tm_detail = {}
+      if time_str.to_s != ''
+        # time_str will be like "PxxYxxMxxDTxxHxxMxxS"
+        # Ignoring 'P' and extracting date and time
+        dt, tm = time_str[1..-1].split('T')
+
+        # Replacing strings
+        if dt.to_s != ''
+          dt['Y'] = 'year' if dt['Y']; dt['M'] = 'month' if dt['M']; dt['D'] = 'day' if dt['D']
+          dt_tm_array_to_hash(dt, tm_detail)
+        end
+
+        if tm.to_s != ''
+          tm['H'] = 'hour' if tm['H']; tm['M'] = 'min' if tm['M']; tm['S'] = 'sec' if tm['S']
+          dt_tm_array_to_hash(tm, tm_detail)
+        end
+      end
+      tm_detail
+    end
+
+    # Method to convert date/time array to hash
+    def dt_tm_array_to_hash(arr, tm_detail)
+      arr.split(/(\d+)/)[1..-1].each_slice(2).inject(tm_detail) { |h, i| h[i.last.to_sym] = i.first; h }
+    end
+  end
+end

--- a/lib/win32/windows/time_calc_helper.rb
+++ b/lib/win32/windows/time_calc_helper.rb
@@ -3,13 +3,13 @@ module Windows
 
     # Returns actual no of days for given month;
     # Array with a 0 is defined to give actual result without
-    # any manipulation. eg, DAY_OF_MONTH[1] = 31
+    # any manipulation. eg, DAYS_IN_A_MONTH[1] = 31
     # 0(NUMBER) is kept to avoid exceptions during calculations
-    DAY_OF_MONTH = [0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+    DAYS_IN_A_MONTH = [0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
 
     # Returns no of days in a given month of a year
     def day_in_month(month, year)
-      (month == 2 && is_leap_year?(year)) ? 29 : DAY_OF_MONTH[month]
+      (month == 2 && is_leap_year?(year)) ? 29 : DAYS_IN_A_MONTH[month]
     end
 
     # Year is leap when it is a multiple of 4 and not a multiple of 100.

--- a/lib/win32/windows/time_calc_helper.rb
+++ b/lib/win32/windows/time_calc_helper.rb
@@ -72,7 +72,7 @@ module Windows
 
       loop do
        days -= day_in_month(mth, yr)
-       break if days < 0
+       break if days <= 0
        mth += 1
        if mth > 12
          mth = 1; yr += 1

--- a/lib/win32/windows/time_calc_helper.rb
+++ b/lib/win32/windows/time_calc_helper.rb
@@ -45,7 +45,7 @@ module Windows
       # They may stretch upto years; heance leap year & months are into consideration
       future_day, future_month, future_year = extra_days(future_day, future_month, future_year, curr_time.month, curr_time.year)
 
-      future_month, future_year = extra_time(future_month, future_year, 12)
+      future_month, future_year = extra_months(future_month, future_year, curr_time.month, curr_time.year)
 
       future_time = Time.new(future_year, future_month, future_day, future_hr, future_min, future_sec)
 
@@ -61,6 +61,16 @@ module Windows
       a, b = low_rank.divmod(div_val)
       high_rank += a; low_rank = b
       [low_rank, high_rank]
+    end
+
+    def extra_months(month_count, year_count, init_month, init_year)
+      year, month_count = month_count.divmod(12)
+      if year.positive? && month_count.zero?
+        month_count = 12
+        year -= 1
+      end
+      year_count += year
+      [month_count, year_count]
     end
 
     # Returns no of actual days with all overloaded months & Years

--- a/lib/win32/windows/time_calc_helper.rb
+++ b/lib/win32/windows/time_calc_helper.rb
@@ -8,7 +8,7 @@ module Windows
     DAYS_IN_A_MONTH = [0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
 
     # Returns no of days in a given month of a year
-    def day_in_month(month, year)
+    def days_in_month(month, year)
       (month == 2 && is_leap_year?(year)) ? 29 : DAYS_IN_A_MONTH[month]
     end
 
@@ -81,7 +81,7 @@ module Windows
       yr = init_year
 
       loop do
-       days -= day_in_month(mth, yr)
+       days -= days_in_month(mth, yr)
        break if days <= 0
        mth += 1
        if mth > 12

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,1 @@
+$LOAD_PATH.unshift File.expand_path('../lib/win32', __dir__)

--- a/spec/win32/windows/time_calc_helper_spec.rb
+++ b/spec/win32/windows/time_calc_helper_spec.rb
@@ -1,0 +1,392 @@
+require 'win32/windows/time_calc_helper'
+require 'spec_helper'
+
+RSpec.describe Windows::TimeCalcHelper do
+  let(:object) { klass.new }
+  let(:klass) do
+    Class.new do
+      include Windows::TimeCalcHelper
+    end
+  end
+
+  describe 'Format Test:' do
+    context 'An Invalid Date-Time string' do
+      time_str = 'An Invalid String'
+      let(:time_details) { object.time_details(time_str) }
+      it 'Returns an empty hash' do
+        expect(time_details).to be_a(Hash)
+        expect(time_details).to be_empty
+      end
+    end
+
+    context 'A valid Date string' do
+      time_str = 'P1Y2M3D'
+      let(:time_details) { object.time_details(time_str) }
+      it 'Returns a valid Hash with only Date values' do
+        expect(time_details).to be_a(Hash)
+        expect(time_details[:year]).to eql('1')
+        expect(time_details[:month]).to eql('2')
+        expect(time_details[:day]).to eql('3')
+        expect(time_details[:hour]).to be_nil
+        expect(time_details[:min]).to be_nil
+        expect(time_details[:sec]).to be_nil
+      end
+    end
+
+    context 'A valid Time string' do
+      time_str = 'PT4H5M6S'
+      let(:time_details) { object.time_details(time_str) }
+      it 'Returns a valid Hash with only Time values' do
+        expect(time_details).to be_a(Hash)
+        expect(time_details[:year]).to be_nil
+        expect(time_details[:month]).to be_nil
+        expect(time_details[:day]).to be_nil
+        expect(time_details[:hour]).to eql('4')
+        expect(time_details[:min]).to eql('5')
+        expect(time_details[:sec]).to eql('6')
+      end
+    end
+
+    context 'A valid Date-Time string' do
+      time_str = 'P1Y2M3DT4H5M6S'
+      let(:time_details) { object.time_details(time_str) }
+      it 'returns a valid Hash with values' do
+        expect(time_details).to be_a(Hash)
+        expect(time_details[:year]).to eql('1')
+        expect(time_details[:month]).to eql('2')
+        expect(time_details[:day]).to eql('3')
+        expect(time_details[:hour]).to eql('4')
+        expect(time_details[:min]).to eql('5')
+        expect(time_details[:sec]).to eql('6')
+      end
+    end
+
+    context 'An Unformatted Date-Time string' do
+      time_str = 'P2M3D1YT6S5M4H'
+      let(:time_details) { object.time_details(time_str) }
+      it 'Returns a valid Hash with values' do
+        expect(time_details).to be_a(Hash)
+        expect(time_details[:year]).to eql('1')
+        expect(time_details[:month]).to eql('2')
+        expect(time_details[:day]).to eql('3')
+        expect(time_details[:hour]).to eql('4')
+        expect(time_details[:min]).to eql('5')
+        expect(time_details[:sec]).to eql('6')
+      end
+    end
+
+    context 'A Date-Time string with few parameters' do
+      time_str = 'P1Y2MT3M4S'
+      let(:time_details) { object.time_details(time_str) }
+      it 'Returns a valid Hash with selected values' do
+        expect(time_details).to be_a(Hash)
+        expect(time_details[:year]).to eql('1')
+        expect(time_details[:month]).to eql('2')
+        expect(time_details[:day]).to be_nil
+        expect(time_details[:hour]).to be_nil
+        expect(time_details[:min]).to eql('3')
+        expect(time_details[:sec]).to eql('4')
+      end
+    end
+  end
+
+  describe 'Year conversion:' do
+    # Time.now to be a Non-Leap Year(0001-01-01 00:00:00), So that
+    # Tests suites will be independant of their execution Time
+    before(:each) do
+      allow(Time).to receive(:now).and_return(Time.new(1))
+    end
+
+    let(:current_time) { Time.new(1) }
+    context 'on given year' do
+      time_str = 'P1Y'
+      let(:time_seconds) { object.time_in_seconds(time_str) }
+      let(:next_time) { current_time + time_seconds }
+      it 'returns expected year' do
+        expect(next_time.year).to eql(current_time.year + 1)
+        expect(next_time.month).to eql(current_time.month)
+        expect(next_time.day).to eql(current_time.day)
+        expect(next_time.hour).to eql(current_time.hour)
+        expect(next_time.min).to eql(current_time.min)
+        expect(next_time.sec).to eql(current_time.sec)
+      end
+    end
+
+    context 'on given months' do
+      time_str = 'P12M'
+      let(:time_seconds) { object.time_in_seconds(time_str) }
+      let(:next_time) { current_time + time_seconds }
+      it 'returns expected year' do
+        expect(next_time.year).to eql(current_time.year + 1)
+        expect(next_time.month).to eql(current_time.month)
+        expect(next_time.day).to eql(current_time.day)
+        expect(next_time.hour).to eql(current_time.hour)
+        expect(next_time.min).to eql(current_time.min)
+        expect(next_time.sec).to eql(current_time.sec)
+      end
+    end
+
+    context 'on given days' do
+      time_str = 'P365D'
+      let(:time_seconds) { object.time_in_seconds(time_str) }
+      let(:next_time) { current_time + time_seconds }
+      it 'returns expected year' do
+        expect(next_time.year).to eql(current_time.year + 1)
+        expect(next_time.month).to eql(current_time.month)
+        expect(next_time.day).to eql(current_time.day)
+        expect(next_time.hour).to eql(current_time.hour)
+        expect(next_time.min).to eql(current_time.min)
+        expect(next_time.sec).to eql(current_time.sec)
+      end
+    end
+
+    context 'by given year and month' do
+      time_str = 'P1Y12M'
+      let(:time_seconds) { object.time_in_seconds(time_str) }
+      let(:next_time) { current_time + time_seconds }
+      it 'returns expected year' do
+        expect(next_time.year).to eql(current_time.year + 2)
+        expect(next_time.month).to eql(current_time.month)
+        expect(next_time.day).to eql(current_time.day)
+        expect(next_time.hour).to eql(current_time.hour)
+        expect(next_time.min).to eql(current_time.min)
+        expect(next_time.sec).to eql(current_time.sec)
+      end
+    end
+
+    context 'by given year, months and days' do
+      time_str = 'P1Y12M365D'
+      let(:time_seconds) { object.time_in_seconds(time_str) }
+      let(:next_time) { current_time + time_seconds }
+      it 'Returns the actual incremented day' do
+        expect(next_time.year).to eql(current_time.year + 3)
+        expect(next_time.month).to eql(current_time.month)
+        expect(next_time.day).to eql(current_time.day)
+        expect(next_time.hour).to eql(current_time.hour)
+        expect(next_time.min).to eql(current_time.min)
+        expect(next_time.sec).to eql(current_time.sec)
+      end
+    end
+  end
+
+  describe 'Month conversion:' do
+    # Time.now to be a Non-Leap Year(0001-01-01 00:00:00), So that
+    # Tests suites will be independant of their execution Time
+    before(:each) do
+      allow(Time).to receive(:now).and_return(Time.new(1))
+    end
+
+    let(:current_time) { Time.new(1) }
+    context 'on given month' do
+      time_str = 'P1M'
+      let(:time_seconds) { object.time_in_seconds(time_str) }
+      let(:next_time) { current_time + time_seconds }
+      it 'returns expected month' do
+        expect(next_time.year).to eql(current_time.year)
+        expect(next_time.month).to eql(current_time.month + 1)
+        expect(next_time.day).to eql(current_time.day)
+        expect(next_time.hour).to eql(current_time.hour)
+        expect(next_time.min).to eql(current_time.min)
+        expect(next_time.sec).to eql(current_time.sec)
+      end
+    end
+
+    context 'on given days' do
+      # Since we are running test on 1st month, next month will occur in 31 days
+      time_str = 'P31D'
+      let(:time_seconds) { object.time_in_seconds(time_str) }
+      let(:next_time) { current_time + time_seconds }
+      it 'returns expected month' do
+        expect(next_time.year).to eql(current_time.year)
+        expect(next_time.month).to eql(current_time.month + 1)
+        expect(next_time.day).to eql(current_time.day)
+        expect(next_time.hour).to eql(current_time.hour)
+        expect(next_time.min).to eql(current_time.min)
+        expect(next_time.sec).to eql(current_time.sec)
+      end
+    end
+
+    context 'by given month and days' do
+      # Since we are running test on 1st month, next month will occur in 31 days
+      time_str = 'P1M31D'
+      let(:time_seconds) { object.time_in_seconds(time_str) }
+      let(:next_time) { current_time + time_seconds }
+      it 'returns expected month' do
+        expect(next_time.year).to eql(current_time.year)
+        expect(next_time.month).to eql(current_time.month + 2)
+        expect(next_time.day).to eql(current_time.day)
+        expect(next_time.hour).to eql(current_time.hour)
+        expect(next_time.min).to eql(current_time.min)
+        expect(next_time.sec).to eql(current_time.sec)
+      end
+    end
+  end
+
+  describe 'Day conversion:' do
+    # Time.now to be a Non-Leap Year(0001-01-01 00:00:00), So that
+    # Tests suites will be independant of their execution Time
+    before(:each) do
+      allow(Time).to receive(:now).and_return(Time.new(1))
+    end
+
+    let(:current_time) { Time.new(1) }
+    context 'on given days' do
+      time_str = 'P1D'
+      let(:time_seconds) { object.time_in_seconds(time_str) }
+      let(:next_time) { current_time + time_seconds }
+      it 'returns expected days' do
+        expect(next_time.year).to eql(current_time.year)
+        expect(next_time.month).to eql(current_time.month)
+        expect(next_time.day).to eql(current_time.day + 1)
+        expect(next_time.hour).to eql(current_time.hour)
+        expect(next_time.min).to eql(current_time.min)
+        expect(next_time.sec).to eql(current_time.sec)
+      end
+    end
+
+    context 'on given hours' do
+      time_str = 'PT24H'
+      let(:time_seconds) { object.time_in_seconds(time_str) }
+      let(:next_time) { current_time + time_seconds }
+      it 'returns expected days' do
+        expect(next_time.year).to eql(current_time.year)
+        expect(next_time.month).to eql(current_time.month)
+        expect(next_time.day).to eql(current_time.day + 1)
+        expect(next_time.hour).to eql(current_time.hour)
+        expect(next_time.min).to eql(current_time.min)
+        expect(next_time.sec).to eql(current_time.sec)
+      end
+    end
+
+    context 'on given minutes' do
+      time_str = 'PT1440M'
+      let(:time_seconds) { object.time_in_seconds(time_str) }
+      let(:next_time) { current_time + time_seconds }
+      it 'returns expected days' do
+        expect(next_time.year).to eql(current_time.year)
+        expect(next_time.month).to eql(current_time.month)
+        expect(next_time.day).to eql(current_time.day + 1)
+        expect(next_time.hour).to eql(current_time.hour)
+        expect(next_time.min).to eql(current_time.min)
+        expect(next_time.sec).to eql(current_time.sec)
+      end
+    end
+
+    context 'on given seconds' do
+      time_str = 'PT86400S'
+      let(:time_seconds) { object.time_in_seconds(time_str) }
+      let(:next_time) { current_time + time_seconds }
+      it 'returns expected days' do
+        expect(next_time.year).to eql(current_time.year)
+        expect(next_time.month).to eql(current_time.month)
+        expect(next_time.day).to eql(current_time.day + 1)
+        expect(next_time.hour).to eql(current_time.hour)
+        expect(next_time.min).to eql(current_time.min)
+        expect(next_time.sec).to eql(current_time.sec)
+      end
+    end
+
+    context 'By the given days, hours, minutes and seconds' do
+      time_str = 'P1DT24H1440M86400S'
+      let(:time_seconds) { object.time_in_seconds(time_str) }
+      let(:next_time) { current_time + time_seconds }
+      it 'returns expected days' do
+        expect(next_time.year).to eql(current_time.year)
+        expect(next_time.month).to eql(current_time.month)
+        expect(next_time.day).to eql(current_time.day + 4)
+        expect(next_time.hour).to eql(current_time.hour)
+        expect(next_time.min).to eql(current_time.min)
+        expect(next_time.sec).to eql(current_time.sec)
+      end
+    end
+  end
+
+  describe 'Minute conversion:' do
+    # Time.now to be a Non-Leap Year(0001-01-01 00:00:00), So that
+    # Tests suites will be independant of their execution Time
+    before(:each) do
+      allow(Time).to receive(:now).and_return(Time.new(1))
+    end
+
+    let(:current_time) { Time.new(1) }
+    context 'on given minute' do
+      time_str = 'PT1M'
+      let(:time_seconds) { object.time_in_seconds(time_str) }
+      let(:next_time) { current_time + time_seconds }
+      it 'returns expected minutes' do
+        expect(next_time.year).to eql(current_time.year)
+        expect(next_time.month).to eql(current_time.month)
+        expect(next_time.day).to eql(current_time.day)
+        expect(next_time.hour).to eql(current_time.hour)
+        expect(next_time.min).to eql(current_time.min + 1)
+        expect(next_time.sec).to eql(current_time.sec)
+      end
+    end
+
+    context 'on given seconds' do
+      time_str = 'PT60S'
+      let(:time_seconds) { object.time_in_seconds(time_str) }
+      let(:next_time) { current_time + time_seconds }
+      it 'returns expected minutes' do
+        expect(next_time.year).to eql(current_time.year)
+        expect(next_time.month).to eql(current_time.month)
+        expect(next_time.day).to eql(current_time.day)
+        expect(next_time.hour).to eql(current_time.hour)
+        expect(next_time.min).to eql(current_time.min + 1)
+        expect(next_time.sec).to eql(current_time.sec)
+      end
+    end
+
+    context 'By given minutes and seconds' do
+      time_str = 'PT1M60S'
+      let(:time_seconds) { object.time_in_seconds(time_str) }
+      let(:next_time) { current_time + time_seconds }
+      it 'returns expected minutes' do
+        expect(next_time.year).to eql(current_time.year)
+        expect(next_time.month).to eql(current_time.month)
+        expect(next_time.day).to eql(current_time.day)
+        expect(next_time.hour).to eql(current_time.hour)
+        expect(next_time.min).to eql(current_time.min + 2)
+        expect(next_time.sec).to eql(current_time.sec)
+      end
+    end
+  end
+
+  describe 'Date-Time conversions:' do
+    # For a single string given in leap/non-leap year
+    time_str = 'P400Y500M600DT700H800M900S'
+
+    context 'In a non leap year' do
+      let(:current_time) { Time.new(1) }
+      let(:time_seconds) { object.time_in_seconds(time_str) }
+      let(:next_time) { current_time + time_seconds }
+      it 'returns expected values' do
+        allow(Time).to receive(:now).and_return(Time.new(1))
+
+        expect(next_time.year).to eql(current_time.year + 443)
+        expect(next_time.month).to eql(current_time.month + 4)
+        expect(next_time.day).to eql(current_time.day + 21)
+        expect(next_time.hour).to eql(current_time.hour + 17)
+        expect(next_time.min).to eql(current_time.min + 35)
+        expect(next_time.sec).to eql(current_time.sec)
+      end
+    end
+
+    context 'In a leap year' do
+      let(:current_time) { Time.new(0) }
+      let(:time_seconds) { object.time_in_seconds(time_str) }
+      let(:next_time) { current_time + time_seconds }
+      it 'returns expected values' do
+        allow(Time).to receive(:now).and_return(Time.new(0))
+
+        # 1 Day less for the same string
+        expect(next_time.year).to eql(current_time.year + 443)
+        expect(next_time.month).to eql(current_time.month + 4)
+        expect(next_time.day).to eql(current_time.day + 20)
+        expect(next_time.hour).to eql(current_time.hour + 17)
+        expect(next_time.min).to eql(current_time.min + 35)
+        expect(next_time.sec).to eql(current_time.sec)
+      end
+    end
+  end
+end

--- a/win32-taskscheduler.gemspec
+++ b/win32-taskscheduler.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency('test-unit')
   spec.add_development_dependency('rake')
   spec.add_development_dependency('win32-security')
+  spec.add_development_dependency "rspec", "~>3.0"
 
   spec.extra_rdoc_files = [
     'README',


### PR DESCRIPTION
For an example when time_str = 'PT1M60S' it will be either '2 mins' OR '120 seconds' in total.
`time_in_minutes(time_str)` OR `time_in_seconds(time_str)` will give above results respectively.

* This may stretch up to hours/days/months even years

Significance: When a user inserts some random time interval while creating/updating a task (say in minutes; (65)) ,then during retrieving trigger's information, windows returns PT1M5S. Hence, he must be able to check this result as 65 mins again.

Signed-off-by: Nimesh Patni <nimesh.patni@msystechnologies.com>