### PR TITLE
Move Win32::TaskScheduler::VERSION to another file

### DIFF
--- a/.expeditor/update_version.sh
+++ b/.expeditor/update_version.sh
@@ -6,7 +6,7 @@
 
 set -evx
 
-sed -i -r "s/^(\s*)VERSION = '.+'/\1VERSION = '$(cat VERSION)'/" lib/win32/taskscheduler.rb
+sed -i -r "s/^(\s*)VERSION = '.+'/\1VERSION = '$(cat VERSION)'/" lib/win32/taskscheduler/version.rb
 
 # Once Expeditor finshes executing this script, it will commit the changes and push
 # the commit as a new tag corresponding to the value in the VERSION file.

--- a/lib/win32/taskscheduler.rb
+++ b/lib/win32/taskscheduler.rb
@@ -1,6 +1,7 @@
 require_relative 'windows/helper'
 require_relative 'windows/time_calc_helper'
 require_relative 'windows/constants'
+require_relative 'taskscheduler/version'
 require 'win32ole'
 require 'socket'
 require 'time'
@@ -14,9 +15,6 @@ module Win32
     include Windows::TaskSchedulerHelper
     include Windows::TimeCalcHelper
     include Windows::TaskSchedulerConstants
-
-    # The version of the win32-taskscheduler library
-    VERSION = '1.0.1'.freeze
 
     # The Error class is typically raised if any TaskScheduler methods fail.
     class Error < StandardError; end

--- a/lib/win32/taskscheduler/version.rb
+++ b/lib/win32/taskscheduler/version.rb
@@ -1,0 +1,6 @@
+module Win32
+  class TaskScheduler
+    # The version of the win32-taskscheduler library
+    VERSION = '1.0.1'.freeze
+  end
+end

--- a/win32-taskscheduler.gemspec
+++ b/win32-taskscheduler.gemspec
@@ -1,11 +1,11 @@
 require 'rubygems'
-require_relative 'lib/win32/taskscheduler'
+require_relative 'lib/win32/taskscheduler/version'
 
 Gem::Specification.new do |spec|
   spec.name       = 'win32-taskscheduler'
   spec.version    = Win32::TaskScheduler::VERSION
   spec.authors    = ['Park Heesob', 'Daniel J. Berger']
-  spec.license    = 'Artistic 2.0'
+  spec.license    = 'Artistic-2.0'
   spec.email      = 'djberg96@gmail.com'
   spec.homepage   = 'http://github.com/chef/win32-taskscheduler'
   spec.summary    = 'A library for the Windows task scheduler'


### PR DESCRIPTION
Allow uing Win32::TaskScheduler::VERSION in the gemspec by moving it to another
file to avoid having to load all the dependencies.

Signed-off-by: Bryan McLellan <btm@loftninjas.org>