### PR TITLE
Fix priority should return unique value.

### DIFF
--- a/lib/win32/taskscheduler.rb
+++ b/lib/win32/taskscheduler.rb
@@ -479,19 +479,19 @@ module Win32
         when 1
           priority = 'highest'
         when 2
-          priority = 'above_normal'
+          priority = 'above_normal_2'
         when 3
-          priority = 'above_normal'
+          priority = 'above_normal_3'
         when 4
-          priority = 'normal'
+          priority = 'normal_4'
         when 5
-          priority = 'normal'
+          priority = 'normal_5'
         when 6
-          priority = 'normal'
+          priority = 'normal_6'
         when 7
-          priority = 'below_normal'
+          priority = 'below_normal_7'
         when 8
-          priority = 'below_normal'
+          priority = 'below_normal_8'
         when 9
           priority = 'lowest'
         when 10

--- a/lib/win32/taskscheduler.rb
+++ b/lib/win32/taskscheduler.rb
@@ -466,9 +466,9 @@ module Win32
       dir
     end
 
-    # Returns the task's priority level. Possible values are 'idle',
-    # 'normal', 'high', 'realtime', 'below_normal', 'above_normal',
-    # and 'unknown'.
+    # Returns the task's priority level. Possible values are 'idle', 'lowest'.
+    # 'below_normal_8', 'below_normal_7', 'normal_6', 'normal_5', 'normal_4',
+    # 'above_normal_3', 'above_normal_2', 'highest', 'critical' and 'unknown'.
     #
     def priority
       check_for_active_task

--- a/spec/functional/win32/taskschedular_spec.rb
+++ b/spec/functional/win32/taskschedular_spec.rb
@@ -308,16 +308,86 @@ RSpec.describe Win32::TaskScheduler, :windows_only do
 
   describe '#priority' do
     before { create_task }
-    it 'Returns the priority of task' do
-      check = 'below_normal'
+    it 'Returns default priority of task' do
+      check = 'below_normal_7'
       expect(@ts.priority).to eq(check)
     end
 
-    it 'Sets the priority of task' do
+    it '0 Sets the priority of task to critical' do
+      stub_user
+      check = 0
+      expect(@ts.priority = check).to eq(check)
+      expect(@ts.priority).to eq('critical')
+    end
+
+    it '1 Sets the priority of task to highest' do
+      stub_user
+      check = 1
+      expect(@ts.priority = check).to eq(check)
+      expect(@ts.priority).to eq('highest')
+    end
+
+    it '2 Sets the priority of task to above_normal_2' do
+      stub_user
+      check = 2
+      expect(@ts.priority = check).to eq(check)
+      expect(@ts.priority).to eq('above_normal_2')
+    end
+
+    it '3 Sets the priority of task to above_normal_3' do
+      stub_user
+      check = 3
+      expect(@ts.priority = check).to eq(check)
+      expect(@ts.priority).to eq('above_normal_3')
+    end
+
+    it '4 Sets the priority of task to normal_4' do
       stub_user
       check = 4
       expect(@ts.priority = check).to eq(check)
-      expect(@ts.priority).to eq('normal')
+      expect(@ts.priority).to eq('normal_4')
+    end
+
+    it '5 Sets the priority of task to normal_5' do
+      stub_user
+      check = 5
+      expect(@ts.priority = check).to eq(check)
+      expect(@ts.priority).to eq('normal_5')
+    end
+
+    it '6 Sets the priority of task to normal_6' do
+      stub_user
+      check = 6
+      expect(@ts.priority = check).to eq(check)
+      expect(@ts.priority).to eq('normal_6')
+    end
+
+    it '7 Sets the priority of task to below_normal_7' do
+      stub_user
+      check = 7
+      expect(@ts.priority = check).to eq(check)
+      expect(@ts.priority).to eq('below_normal_7')
+    end
+
+    it '8 Sets the priority of task to below_normal_8' do
+      stub_user
+      check = 8
+      expect(@ts.priority = check).to eq(check)
+      expect(@ts.priority).to eq('below_normal_8')
+    end
+
+    it '9 Sets the priority of task to lowest' do
+      stub_user
+      check = 9
+      expect(@ts.priority = check).to eq(check)
+      expect(@ts.priority).to eq('lowest')
+    end
+
+    it '10 Sets the priority of task to idle' do
+      stub_user
+      check = 10
+      expect(@ts.priority = check).to eq(check)
+      expect(@ts.priority).to eq('idle')
     end
 
     it 'Raises an error if task does not exists' do


### PR DESCRIPTION
Signed-off-by: vasu1105 <vasundhara.jagdale@msystechnologies.com>

### Description
win32-taskscheduler the values which are returned for priority are in string format and some of them are having same description like for priority 2 and 3 the value which is return from library is `above_normal` due to which we are not able differentiate between previous value and the updated value 

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
