### PR TITLE
Fix exists? method breaking task full path search

### DIFF
--- a/lib/win32/taskscheduler.rb
+++ b/lib/win32/taskscheduler.rb
@@ -199,9 +199,7 @@ module Win32
       path = nil
       task_name = nil
 
-      # Used the splat operator to put all folder elements into path and leave only the task name`
       if full_task_path.include?("\\")
-        full_task_path = root_path + full_task_path
         *path, task_name = full_task_path.split('\\')
       else
         task_name = full_task_path

--- a/spec/functional/win32/taskschedular_spec.rb
+++ b/spec/functional/win32/taskschedular_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe Win32::TaskScheduler, :windows_only do
 
       it 'at nested folder' do
         @ts = Win32::TaskScheduler.new(@task, @trigger, folder, force)
-        task = folder + '\\' + @task
+        task = @test_path + folder + '\\' + @task
         expect(@ts.exists?(task)).to be_truthy
       end
     end

--- a/spec/unit/win32/taskschedular_spec.rb
+++ b/spec/unit/win32/taskschedular_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Win32::TaskScheduler, :windows_only do
       end
 
       it 'Does not require root to be appended' do
-        task = @folder + '\\' + @task
+        task = @test_path + @folder + '\\' + @task
         expect(@ts.exists?(task)).to be_falsey
       end
     end
@@ -85,7 +85,7 @@ RSpec.describe Win32::TaskScheduler, :windows_only do
 
       it 'Returns true for existing folder' do
         @ts = Win32::TaskScheduler.new(@task, @trigger, folder, force)
-        task = folder + '\\' + @task
+        task = @test_path + folder + '\\' + @task
         expect(@ts.exists?(task)).to be_truthy
       end
     end


### PR DESCRIPTION
Signed-off-by: vasu1105 <vasundhara.jagdale@msystechnologies.com>

### Description

Fix for exists? method breaking task full path search since there is additional '\' added in search

### Issues Resolved

It fixes breaking of chef windows_task resource.

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
