### PR TITLE
Fix order of expeditor promotion actions

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -21,8 +21,8 @@ github:
         version_constraint: "1.*"
 promote:
   action:
-    - built_in:publish_rubygems
     - built_in:rollover_changelog
+    - built_in:publish_rubygems
 
 # These actions are taken, in order they are specified, anytime a Pull Request is merged.
 merge_actions:


### PR DESCRIPTION
We're seeing an expeditor config-002 validation error. AFAICT the merge actions are in the right order, so maybe it's the promote actions.

https://expeditor.chef.io/docs/reference/status-checks/#config-002