### PR TITLE
Allow non-system users to create/update an interactive task without password

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,9 +13,9 @@ group :ci do
 end
 
 group :docs do
-  gem "yard"
-  gem "redcarpet"
   gem "github-markup"
+  gem "redcarpet"
+  gem "yard"
 end
 
 group :debug do

--- a/Rakefile
+++ b/Rakefile
@@ -63,4 +63,4 @@ task :console do
   IRB.start
 end
 
-task default: [:style, :spec]
+task default: %i{style spec}

--- a/examples/taskscheduler_example.rb
+++ b/examples/taskscheduler_example.rb
@@ -25,7 +25,7 @@ trigger = {
   type: { "days_interval" => 1 },
 }
 
-unless ts.enum.grep(/foo/).length > 0
+if ts.enum.grep(/foo/).empty?
   ts.new_work_item("foo", trigger)
   ts.application_name = "notepad.exe"
   puts "Task Added"
@@ -33,7 +33,7 @@ end
 
 ts.activate("foo")
 ts.priority = TaskScheduler::IDLE
-ts.working_directory = "C:\\"
+ts.working_directory = 'C:\\'
 
 puts "App name: " + ts.application_name
 puts "Creator: " + ts.creator

--- a/lib/win32/taskscheduler/helper.rb
+++ b/lib/win32/taskscheduler/helper.rb
@@ -12,11 +12,11 @@ module Win32
       ffi_lib :kernel32, :advapi32
 
       attach_function :FormatMessage, :FormatMessageA,
-      [:ulong, :pointer, :ulong, :ulong, :pointer, :ulong, :pointer], :ulong
+                      %i{ulong pointer ulong ulong pointer ulong pointer}, :ulong
 
-      attach_function :ConvertStringSidToSidW, [ :pointer, :pointer ], :bool
-      attach_function :LookupAccountSidW, [ :pointer, :pointer, :pointer, :pointer, :pointer, :pointer, :pointer ], :bool
-      attach_function :LocalFree, [ :pointer ], :pointer
+      attach_function :ConvertStringSidToSidW, %i{pointer pointer}, :bool
+      attach_function :LookupAccountSidW, %i{pointer pointer pointer pointer pointer pointer pointer}, :bool
+      attach_function :LocalFree, [:pointer], :pointer
 
       def win_error(function, err = FFI.errno)
         err_msg = ""
@@ -28,7 +28,7 @@ module Win32
         # We use English for errors because Ruby uses English for errors.
 
         FFI::MemoryPointer.new(:char, 1024) do |buf|
-          len = FormatMessage(flags, nil, err , 0x0409, buf, buf.size, nil)
+          len = FormatMessage(flags, nil, err, 0x0409, buf, buf.size, nil)
           err_msg = function + ": " + buf.read_string(len).strip
         end
 

--- a/spec/functional/win32/taskscheduler_spec.rb
+++ b/spec/functional/win32/taskscheduler_spec.rb
@@ -521,50 +521,113 @@ RSpec.describe Win32::TaskScheduler, :windows_only do
     context "Service Account Users" do
       let(:service_user) { "LOCAL SERVICE" }
       let(:password) { nil }
-      it "Does not require any password" do
-        expect(@ts.set_account_information(service_user, password)). to be_truthy
-        expect(@ts.account_information.upcase).to eq(service_user)
+      context "when task is Interactive" do
+        let(:interactive) { true }
+        it "Does not require any password" do
+          expect(@ts.set_account_information(service_user, password, interactive)). to be_truthy
+          expect(@ts.account_information.upcase).to eq(service_user)
+        end
+
+        it "passing account_name will display account_simple_name" do
+          user = 'NT AUTHORITY\LOCAL SERVICE'
+          expect(@ts.set_account_information(user, password, interactive)). to be_truthy
+          expect(@ts.account_information.upcase).to eq(service_user)
+        end
+
+        it "Raises an error if password is given" do
+          password = "XYZ"
+          expect { @ts.set_account_information(service_user, password, interactive) }. to raise_error(ArgumentError)
+        end
       end
-      it "passing account_name will display account_simple_name" do
-        user = 'NT AUTHORITY\LOCAL SERVICE'
-        expect(@ts.set_account_information(user, password)). to be_truthy
-        expect(@ts.account_information.upcase).to eq(service_user)
-      end
-      it "Raises an error if password is given" do
-        password = "XYZ"
-        expect { @ts.set_account_information(service_user, password) }. to raise_error(tasksch_err)
+
+      context "when task is Non-Interactive" do
+        let(:interactive) { false }
+        it "Does not require any password" do
+          expect(@ts.set_account_information(service_user, password, interactive)). to be_truthy
+          expect(@ts.account_information.upcase).to eq(service_user)
+        end
+
+        it "passing account_name will display account_simple_name" do
+          user = 'NT AUTHORITY\LOCAL SERVICE'
+          expect(@ts.set_account_information(user, password, interactive)). to be_truthy
+          expect(@ts.account_information.upcase).to eq(service_user)
+        end
+
+        it "Raises an error if password is given" do
+          password = "XYZ"
+          expect { @ts.set_account_information(service_user, password, interactive) }. to raise_error(ArgumentError)
+        end
       end
     end
+
     context "Built in Groups" do
       let(:group_user) { "USERS" }
       let(:password) { nil }
-      it "Does not require any password" do
-        expect(@ts.set_account_information(group_user, password)). to be_truthy
-        expect(@ts.account_information.upcase).to eq(group_user)
+      context "when task is Interactive" do
+        let(:interactive) { true }
+        it "Does not require any password" do
+          expect(@ts.set_account_information(group_user, password, interactive)). to be_truthy
+          expect(@ts.account_information.upcase).to eq(group_user)
+        end
+
+        it "passing account_name will display account_simple_name" do
+          user = 'BUILTIN\USERS'
+          expect(@ts.set_account_information(user, password, interactive)). to be_truthy
+          expect(@ts.account_information.upcase).to eq(group_user)
+        end
+
+        it "Raises an error if password is given" do
+          password = "XYZ"
+          expect { @ts.set_account_information(group_user, password, interactive) }. to raise_error(ArgumentError)
+        end
       end
-      it "passing account_name will display account_simple_name" do
-        user = 'BUILTIN\USERS'
-        expect(@ts.set_account_information(user, password)). to be_truthy
-        expect(@ts.account_information.upcase).to eq(group_user)
-      end
-      it "Raises an error if password is given" do
-        password = "XYZ"
-        expect { @ts.set_account_information(group_user, password) }. to raise_error(tasksch_err)
+
+      context "when task is Non-Interactive" do
+        let(:interactive) { false }
+        it "Does not require any password" do
+          expect(@ts.set_account_information(group_user, password, interactive)). to be_truthy
+          expect(@ts.account_information.upcase).to eq(group_user)
+        end
+
+        it "passing account_name will display account_simple_name" do
+          user = 'BUILTIN\USERS'
+          expect(@ts.set_account_information(user, password, interactive)). to be_truthy
+          expect(@ts.account_information.upcase).to eq(group_user)
+        end
+
+        it "Raises an error if password is given" do
+          password = "XYZ"
+          expect { @ts.set_account_information(group_user, password, interactive) }. to raise_error(ArgumentError)
+        end
       end
     end
+
     context "Non-system users" do
-      it "Require a password" do
-        user = ENV["user"]
-        password = nil
-        expect { @ts.set_account_information(user, password) }. to raise_error(tasksch_err)
-        expect(@ts.account_information).to include(user)
+      context "when task is Interactive" do
+        let(:interactive) { true }
+        it "Does not require any password" do
+          user = ENV["user"]
+          password = nil
+          expect(@ts.set_account_information(user, password, interactive)). to be_truthy
+          expect(@ts.account_information).to include(user)
+        end
+      end
+      context "when task is Non-Interactive" do
+        let(:interactive) { false }
+        it "Require a password" do
+          user = ENV["user"]
+          password = nil
+          expect { @ts.set_account_information(user, password, interactive) }. to raise_error(ArgumentError)
+          expect(@ts.account_information).to include(user)
+        end
       end
     end
     it "Raises an error if task does not exists" do
       @ts.instance_variable_set(:@task, nil)
       user = "User"
       password = "XXXX"
-      expect { @ts.set_account_information(user, password) }. to raise_error(tasksch_err)
+      interactive = false
+      expect { @ts.set_account_information(user, password, interactive) }. to raise_error(tasksch_err)
       expect(@ts.account_information).to be_nil
     end
   end

--- a/spec/unit/win32/taskscheduler/constants_spec.rb
+++ b/spec/unit/win32/taskscheduler/constants_spec.rb
@@ -6,13 +6,13 @@ RSpec.describe Win32::TaskScheduler, :windows_only do
   describe "Ensuring trigger constants" do
     subject(:ts) { Win32::TaskScheduler }
     describe "to handle scheduled tasks" do
-      [:ONCE, :DAILY, :WEEKLY, :MONTHLYDATE, :MONTHLYDOW].each do |const|
+      %i{ONCE DAILY WEEKLY MONTHLYDATE MONTHLYDOW}.each do |const|
         it { should be_const_defined(const) }
       end
     end
 
     describe "to handle other types" do
-      [:AT_LOGON, :AT_SYSTEMSTART, :ON_IDLE].each do |const|
+      %i{AT_LOGON AT_SYSTEMSTART ON_IDLE}.each do |const|
         it { should be_const_defined(const) }
       end
     end

--- a/test/test_taskscheduler.rb
+++ b/test/test_taskscheduler.rb
@@ -306,8 +306,8 @@ class TC_TaskScheduler < Test::Unit::TestCase
 
   test "max_run_time= works as expected" do
     setup_task
-    assert_nothing_raised { @ts.max_run_time = 20000 }
-    assert_equal(20000, @ts.max_run_time)
+    assert_nothing_raised { @ts.max_run_time = 20_000 }
+    assert_equal(20_000, @ts.max_run_time)
   end
 
   test "max_run_time= requires a numeric argument" do
@@ -339,7 +339,7 @@ class TC_TaskScheduler < Test::Unit::TestCase
   end
 
   test "new_work_item fails if a bogus trigger key is present" do
-    assert_raise(ArgumentError) { @ts.new_work_item("test", { bogus: 1 }) }
+    assert_raise(ArgumentError) { @ts.new_work_item("test", bogus: 1) }
   end
 
   test "new_task is an alias for new_work_item" do
@@ -601,7 +601,7 @@ class TC_TaskScheduler < Test::Unit::TestCase
 
   test "working_directory= works as expected" do
     setup_task
-    assert_nothing_raised { @ts.working_directory = "C:\\" }
+    assert_nothing_raised { @ts.working_directory = 'C:\\' }
   end
 
   test "working_directory= requires a string argument" do


### PR DESCRIPTION
- Minor modifications in `check_credential_requirements` for non-system users
- Added test cases
- Fixes MSYS-925 (Sub-task of MSYS-924)

Signed-off-by: Nimesh <nimesh.patni@msystechnologies.com>

### Description

This is similar to SCHTASKS where they allow a non-system user to create an interactive task without a password. For Non-Interactive tasks, we will still require a password. System users always creates a Non-interactive task without a password.

### Issues Resolved

Once this will be merged, It would be significant to resolve [chef#7834](https://github.com/chef/chef/issues/7834)

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
