### PR TITLE
fix version 2.0.3 and expeditor script

### DIFF
--- a/.expeditor/update_version.sh
+++ b/.expeditor/update_version.sh
@@ -6,7 +6,7 @@
 
 set -evx
 
-sed -i -r "s/^(\s*)VERSION = '.+'/\1VERSION = '$(cat VERSION)'/" lib/win32/taskscheduler/version.rb
+sed -i -r "s/^(\s*)VERSION = \".+\"/\1VERSION = \"$(cat VERSION)\"/" lib/win32/taskscheduler/version.rb
 
 # Once Expeditor finshes executing this script, it will commit the changes and push
 # the commit as a new tag corresponding to the value in the VERSION file.

--- a/lib/win32/taskscheduler/version.rb
+++ b/lib/win32/taskscheduler/version.rb
@@ -1,6 +1,6 @@
 module Win32
   class TaskScheduler
     # The version of the win32-taskscheduler library
-    VERSION = "2.0.1".freeze
+    VERSION = "2.0.3".freeze
   end
 end


### PR DESCRIPTION
chefstyle fixes changed a quote->double-quote in 9b46b2279cacd7d64d25c0233cc6560ea00e59bb so we need to update the expeditor script.

