### PR TITLE
Re-opening a test fix PR with updates

### DIFF
--- a/.expeditor/run_windows_tests.ps1
+++ b/.expeditor/run_windows_tests.ps1
@@ -1,0 +1,17 @@
+# Stop script execution when a non-terminating error occurs
+$ErrorActionPreference = "Stop"
+
+# This will run ruby test on windows platform
+
+Write-Output "--- Bundle install"
+
+bundle config --local path vendor/bundle
+If ($lastexitcode -ne 0) { Exit $lastexitcode }
+
+bundle install --jobs=7 --retry=3
+If ($lastexitcode -ne 0) { Exit $lastexitcode }
+
+Write-Output "--- Bundle Execute"
+
+bundle exec rake
+If ($lastexitcode -ne 0) { Exit $lastexitcode }

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -1,0 +1,34 @@
+---
+expeditor:
+  cached_folders:
+    - vendor
+  defaults:
+    buildkite:
+      retry:
+        automatic:
+          limit: 1
+      timeout_in_minutes: 30
+
+steps:
+
+- label: run-specs-ruby-3.0-windows
+  commands:
+   - .expeditor/run_windows_tests.ps1
+
+  expeditor:
+    executor:
+      docker:
+        host_os: windows
+        shell: ["powershell"]
+        image: rubydistros/windows-2019:3.0
+
+- label: run-specs-ruby-3.1-windows
+  commands:
+   - .expeditor/run_windows_tests.ps1
+
+  expeditor:
+    executor:
+      docker:
+        host_os: windows
+        shell: ["powershell"]
+        image: rubydistros/windows-2019:3.1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,14 +22,3 @@ jobs:
     - run: |
         gem install chefstyle
         chefstyle -c .rubocop.yml
-
-  spellcheck:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: carlosperate/download-file-action@v2.0.0
-        id: download-custom-dictionary
-        with:
-          file-url: 'https://raw.githubusercontent.com/chef/chef_dictionary/main/chef.txt'
-          file-name: 'chef_dictionary.txt'
-      - uses: streetsidesoftware/cspell-action@v2.12.0

--- a/examples/taskscheduler_example.rb
+++ b/examples/taskscheduler_example.rb
@@ -33,7 +33,7 @@ end
 
 ts.activate("foo")
 ts.priority = TaskScheduler::IDLE
-ts.working_directory = 'C:\\'
+ts.working_directory = "C:\\"
 
 puts "App name: " + ts.application_name
 puts "Creator: " + ts.creator

--- a/lib/win32/taskscheduler.rb
+++ b/lib/win32/taskscheduler.rb
@@ -720,7 +720,7 @@ module Win32
       when TASK_TRIGGER_SESSION_STATE_CHANGE
         trigger[:user_id] = trig.UserId if trig.UserId.to_s != ""
         trigger[:delay_duration] = time_in_minutes(trig.Delay)
-        trigger[:state_change] = trig.SessionState
+        # trigger[:state_change] = trig.SessionState
       else
         raise Error, "Unknown trigger type"
       end

--- a/lib/win32/taskscheduler.rb
+++ b/lib/win32/taskscheduler.rb
@@ -3,9 +3,6 @@ require_relative "taskscheduler/helper"
 require_relative "taskscheduler/time_calc_helper"
 require_relative "taskscheduler/constants"
 require_relative "taskscheduler/version"
-require "win32ole"
-require "socket"
-require "time"
 require "structured_warnings"
 
 # The Win32 module serves as a namespace only
@@ -122,7 +119,7 @@ module Win32
     attr_accessor :password
     attr_reader :host
 
-    def root_path(path = '\\')
+    def root_path(path = "\\")
       path
     end
 
@@ -142,7 +139,7 @@ module Win32
       @task     = nil
       @password = nil
 
-      raise ArgumentError, "invalid folder" unless folder.include?('\\')
+      raise ArgumentError, "invalid folder" unless folder.include?("\\")
 
       unless [TrueClass, FalseClass].include?(force.class)
         raise TypeError, "invalid force value"
@@ -197,28 +194,25 @@ module Win32
       path = nil
       task_name = nil
 
-      if full_task_path.include?('\\')
-        *path, task_name = full_task_path.split('\\')
+      if full_task_path.include?("\\")
+        *path, task_name = full_task_path.split("\\")
       else
         task_name = full_task_path
       end
 
-      folder = path.nil? ? root_path : path.join('\\')
+      folder = path.nil? ? root_path : path.join("\\")
 
       begin
         root = @service.GetFolder(folder)
       rescue WIN32OLERuntimeError => err
-        return false
       end
 
       if root.nil?
-        return false
       else
         begin
           task = root.GetTask(task_name)
-          return task && task.Name == task_name
+          task.Name == task_name
         rescue WIN32OLERuntimeError => err
-          return false
         end
       end
     end
@@ -372,6 +366,7 @@ module Win32
     #
     def application_name=(app)
       raise TypeError unless app.is_a?(String)
+
       check_for_active_task
 
       definition = @task.Definition
@@ -407,6 +402,7 @@ module Win32
     #
     def parameters=(param)
       raise TypeError unless param.is_a?(String)
+
       check_for_active_task
 
       definition = @task.Definition
@@ -440,6 +436,7 @@ module Win32
     #
     def working_directory=(dir)
       raise TypeError unless dir.is_a?(String)
+
       check_for_active_task
 
       definition = @task.Definition
@@ -495,6 +492,7 @@ module Win32
     #
     def priority=(priority)
       raise TypeError unless priority.is_a?(Numeric)
+
       check_for_active_task
 
       definition = @task.Definition
@@ -528,6 +526,7 @@ module Win32
 
       unless trigger.empty?
         raise ArgumentError, "Unknown trigger type" unless valid_trigger_option(trigger[:trigger_type])
+
         validate_trigger(trigger)
 
         startTime = format("%04d-%02d-%02dT%02d:%02d:00", trigger[:start_year], trigger[:start_month], trigger[:start_day], trigger[:start_hour], trigger[:start_minute])
@@ -626,6 +625,7 @@ module Win32
     #
     def trigger_string(index)
       raise TypeError unless index.is_a?(Numeric)
+
       check_for_active_task
       index += 1 # first item index is 1
 
@@ -644,6 +644,7 @@ module Win32
     #
     def delete_trigger(index)
       raise TypeError unless index.is_a?(Numeric)
+
       check_for_active_task
       index += 1 # first item index is 1
 
@@ -659,6 +660,7 @@ module Win32
     #
     def trigger(index)
       raise TypeError unless index.is_a?(Numeric)
+
       check_for_active_task
       index += 1 # first item index is 1
 
@@ -974,6 +976,7 @@ module Win32
     #
     def comment=(comment)
       raise TypeError unless comment.is_a?(String)
+
       check_for_active_task
 
       definition = @task.Definition
@@ -998,6 +1001,7 @@ module Win32
     #
     def creator=(creator)
       raise TypeError unless creator.is_a?(String)
+
       check_for_active_task
 
       definition = @task.Definition
@@ -1074,6 +1078,7 @@ module Win32
     #
     def max_run_time=(max_run_time)
       raise TypeError unless max_run_time.is_a?(Numeric)
+
       check_for_active_task
 
       t = max_run_time
@@ -1133,7 +1138,7 @@ module Win32
 
       # Check for invalid setting
       invalid_settings = settings_hash.keys - valid_settings_options
-      raise TypeError, "Invalid setting passed: #{invalid_settings.join(', ')}" unless invalid_settings.empty?
+      raise TypeError, "Invalid setting passed: #{invalid_settings.join(", ")}" unless invalid_settings.empty?
 
       # Some modification is required in user input
       hash = settings_hash.dup
@@ -1151,6 +1156,7 @@ module Win32
         idle_settings = task_settings.IdleSettings
         IdleSettings.each do |setting|
           next if hash[setting].nil?
+
           idle_settings.setproperty(camelize(setting.to_s), hash[setting])
           # This setting is not required to be configured now
           hash.delete(setting)
@@ -1188,6 +1194,7 @@ module Win32
     #
     def configure_registration_info(hash)
       raise TypeError unless hash.is_a?(Hash)
+
       check_for_active_task
 
       definition = @task.Definition
@@ -1223,6 +1230,7 @@ module Win32
     #
     def configure_principals(principals)
       raise TypeError unless principals.is_a?(Hash)
+
       check_for_active_task
       definition = @task.Definition
       definition.Principal.Id = principals[:id] if principals[:id].to_s != ""
@@ -1252,6 +1260,7 @@ module Win32
       settings_hash = {}
       @task.Definition.Settings.ole_get_methods.each do |setting|
         next if setting.name == "XmlText" # not needed
+
         settings_hash[setting.name] = @task.Definition.Settings._getproperty(setting.dispid, [], [])
       end
 

--- a/lib/win32/taskscheduler.rb
+++ b/lib/win32/taskscheduler.rb
@@ -3,7 +3,7 @@ require_relative "taskscheduler/helper"
 require_relative "taskscheduler/time_calc_helper"
 require_relative "taskscheduler/constants"
 require_relative "taskscheduler/version"
-require 'socket'
+require "socket" unless defined?(Socket)
 require "structured_warnings"
 
 # The Win32 module serves as a namespace only

--- a/lib/win32/taskscheduler.rb
+++ b/lib/win32/taskscheduler.rb
@@ -3,6 +3,7 @@ require_relative "taskscheduler/helper"
 require_relative "taskscheduler/time_calc_helper"
 require_relative "taskscheduler/constants"
 require_relative "taskscheduler/version"
+require 'socket'
 require "structured_warnings"
 
 # The Win32 module serves as a namespace only

--- a/lib/win32/taskscheduler.rb
+++ b/lib/win32/taskscheduler.rb
@@ -832,9 +832,6 @@ module Win32
       when TASK_EVENT_TRIGGER_AT_LOGON
         trig.UserId = trigger[:user_id] if trigger[:user_id]
         trig.Delay = "PT#{trigger[:delay_duration] || 0}M"
-      when TASK_EVENT_TRIGGER_AT_LOGON
-        trig.UserId = trigger[:user_id] if trigger[:user_id]
-        trig.Delay = "PT#{trigger[:delay_duration] || 0}M"
         trig.SessionState = trigger[:session_state]
       when TASK_EVENT_TRIGGER_ON_IDLE
         # for setting execution time limit Ref : https://msdn.microsoft.com/en-us/library/windows/desktop/aa380724(v=vs.85).aspx

--- a/lib/win32/taskscheduler.rb
+++ b/lib/win32/taskscheduler.rb
@@ -208,14 +208,17 @@ module Win32
       begin
         root = @service.GetFolder(folder)
       rescue WIN32OLERuntimeError => err
+        return false
       end
 
       if root.nil?
+        false
       else
         begin
           task = root.GetTask(task_name)
-          task.Name == task_name
+          task && task.Name == task_name
         rescue WIN32OLERuntimeError => err
+          false
         end
       end
     end

--- a/lib/win32/taskscheduler.rb
+++ b/lib/win32/taskscheduler.rb
@@ -3,6 +3,8 @@ require_relative "taskscheduler/helper"
 require_relative "taskscheduler/time_calc_helper"
 require_relative "taskscheduler/constants"
 require_relative "taskscheduler/version"
+require "win32ole" unless defined?(WIN32OLE)
+require "time" unless defined?(Time.zone_offset)
 require "socket" unless defined?(Socket)
 require "structured_warnings"
 

--- a/lib/win32/taskscheduler/constants.rb
+++ b/lib/win32/taskscheduler/constants.rb
@@ -204,7 +204,7 @@ module Win32
       # When user connects to local computer like switching users
       TASK_CONSOLE_CONNECT = 1
       # When user disconnects to local computer like switching users
-      TASK_CONSOLE_DISCONNECT = 2 
+      TASK_CONSOLE_DISCONNECT = 2
       # When remote user connects to computer (e.g. RDP)
       TASK_REMOTE_CONNECT = 3
       # When remote user disconnects to computer (e.g. RDP)

--- a/lib/win32/taskscheduler/helper.rb
+++ b/lib/win32/taskscheduler/helper.rb
@@ -1,3 +1,4 @@
+require 'ffi'
 module Win32
   class TaskScheduler
     module Helper

--- a/lib/win32/taskscheduler/helper.rb
+++ b/lib/win32/taskscheduler/helper.rb
@@ -1,5 +1,3 @@
-require "ffi"
-
 module Win32
   class TaskScheduler
     module Helper

--- a/lib/win32/taskscheduler/helper.rb
+++ b/lib/win32/taskscheduler/helper.rb
@@ -1,4 +1,4 @@
-require 'ffi'
+require "ffi" unless defined?(FFI)
 module Win32
   class TaskScheduler
     module Helper

--- a/lib/win32/taskscheduler/sid.rb
+++ b/lib/win32/taskscheduler/sid.rb
@@ -68,6 +68,7 @@ module Win32
         unless ConvertStringSidToSidW(utf8_to_wide(string_sid), result)
           raise FFI::LastError.error
         end
+
         result_pointer = result.read_pointer
         domain, name, use = account(result_pointer)
         LocalFree(result_pointer)
@@ -108,6 +109,7 @@ module Win32
         unless LookupAccountSidW(nil, sid, name, name_size, referenced_domain_name, referenced_domain_name_size, use)
           raise FFI::LastError.error
         end
+
         [referenced_domain_name.read_wstring(referenced_domain_name_size.read_long), name.read_wstring(name_size.read_long), use.read_long]
       end
 

--- a/lib/win32/taskscheduler/time_calc_helper.rb
+++ b/lib/win32/taskscheduler/time_calc_helper.rb
@@ -127,12 +127,11 @@ module Win32
       #   time_details("PT3S") #=> {sec: 3}
       #
       def time_details(time_str)
-
         tm_detail = {}
         if time_str.to_s != ""
           # raising exception if time is not a string
           raise TypeError.new("TypeError: Inccorrect Type please pass input value as a String.") unless time_str.is_a? String
-         
+
           # time_str will be like "PxxYxxMxxDTxxHxxMxxS"
           # Ignoring 'P' and extracting date and time
           dt, tm = time_str[1..-1].split("T")

--- a/lib/win32/taskscheduler/time_calc_helper.rb
+++ b/lib/win32/taskscheduler/time_calc_helper.rb
@@ -128,6 +128,7 @@ module Win32
       #
       def time_details(time_str)
         raise TypeError.new("TypeError: Inccorrect Type please pass input value as a String.") unless time_str.is_a? String
+
         tm_detail = {}
         if time_str.to_s != ""
           # time_str will be like "PxxYxxMxxDTxxHxxMxxS"

--- a/lib/win32/taskscheduler/time_calc_helper.rb
+++ b/lib/win32/taskscheduler/time_calc_helper.rb
@@ -103,6 +103,7 @@ module Win32
         loop do
           days -= days_in_month(mth, yr)
           break if days <= 0
+
           mth += 1
           if mth > 12
             mth = 1; yr += 1

--- a/lib/win32/taskscheduler/time_calc_helper.rb
+++ b/lib/win32/taskscheduler/time_calc_helper.rb
@@ -128,9 +128,11 @@ module Win32
       #
       def time_details(time_str)
         tm_detail = {}
+
+        raise TypeError.new("TypeError: Inccorrect Type please pass input value as a String.") unless time_str.is_a? String
+
         if time_str.to_s != ""
           # raising exception if time is not a string
-          raise TypeError.new("TypeError: Inccorrect Type please pass input value as a String.") unless time_str.is_a? String
 
           # time_str will be like "PxxYxxMxxDTxxHxxMxxS"
           # Ignoring 'P' and extracting date and time

--- a/lib/win32/taskscheduler/time_calc_helper.rb
+++ b/lib/win32/taskscheduler/time_calc_helper.rb
@@ -127,10 +127,12 @@ module Win32
       #   time_details("PT3S") #=> {sec: 3}
       #
       def time_details(time_str)
-        raise TypeError.new("TypeError: Inccorrect Type please pass input value as a String.") unless time_str.is_a? String
 
         tm_detail = {}
         if time_str.to_s != ""
+          # raising exception if time is not a string
+          raise TypeError.new("TypeError: Inccorrect Type please pass input value as a String.") unless time_str.is_a? String
+         
           # time_str will be like "PxxYxxMxxDTxxHxxMxxS"
           # Ignoring 'P' and extracting date and time
           dt, tm = time_str[1..-1].split("T")

--- a/lib/win32/taskscheduler/time_calc_helper.rb
+++ b/lib/win32/taskscheduler/time_calc_helper.rb
@@ -127,6 +127,7 @@ module Win32
       #   time_details("PT3S") #=> {sec: 3}
       #
       def time_details(time_str)
+        raise TypeError.new("TypeError: Inccorrect Type please pass input value as a String.") unless time_str.is_a? String
         tm_detail = {}
         if time_str.to_s != ""
           # time_str will be like "PxxYxxMxxDTxxHxxMxxS"

--- a/spec/functional/win32/taskscheduler_spec.rb
+++ b/spec/functional/win32/taskscheduler_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe Win32::TaskScheduler, :windows_only do
 
       it "at nested folder" do
         @ts = Win32::TaskScheduler.new(@task, @trigger, folder, force)
-        task = @test_path + folder + '\\' + @task
+        task = @test_path + folder + "\\" + @task
         expect(@ts.exists?(task)).to be_truthy
       end
     end
@@ -122,7 +122,7 @@ RSpec.describe Win32::TaskScheduler, :windows_only do
 
       it "at nested folder" do
         @ts = Win32::TaskScheduler.new(@task, @trigger, folder, force)
-        task = folder + '\\' + "invalid"
+        task = folder + "\\" + "invalid"
         expect(@ts.exists?(task)).to be_falsy
       end
     end
@@ -670,8 +670,7 @@ RSpec.describe Win32::TaskScheduler, :windows_only do
 
   describe "#trigger_string" do
     before { create_task }
-    it "Returns a string that describes the current trigger at "\
-       "the specified index for the active task" do
+    it "Returns a string that describes the current trigger at the specified index for the active task" do
       expect(@ts.trigger_string(0)).to be_a(String)
     end
 
@@ -842,8 +841,7 @@ RSpec.describe Win32::TaskScheduler, :windows_only do
   describe "#trigger" do
     before { create_task }
 
-    it "Returns a hash that describes the trigger "\
-       "at the given index for the current task" do
+    it "Returns a hash that describes the trigger at the given index for the current task" do
       trigger = @ts.trigger(0)
       expect(trigger).to be_a(Hash)
       expect(trigger).not_to be_empty

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,8 +12,8 @@ require "date"
 # Creating folder 'Test'; This will be treated as root
 def create_test_folder
   @service ||= service
-  @root_path = '\\'
-  @test_path = '\\Test'
+  @root_path = "\\"
+  @test_path = "\\Test"
   @root_folder = @service.GetFolder(@root_path)
   @test_folder = @root_folder.CreateFolder(@test_path)
   @ts.instance_variable_set(:@root, @test_folder) if @ts
@@ -66,6 +66,7 @@ end
 # the related functionalities over a task in RSpecs
 def create_task
   return nil unless @service
+
   @task_definition = @service.NewTask(0)
   task_registration
   task_prinicipals
@@ -138,8 +139,7 @@ end
 def all_triggers
   all_triggers = {}
 
-  %w{ONCE DAILY WEEKLY MONTHLYDATE MONTHLYDOW
-     ON_IDLE AT_SYSTEMSTART AT_LOGON}.each do |trig_type|
+  %w{ONCE DAILY WEEKLY MONTHLYDATE MONTHLYDOW ON_IDLE AT_SYSTEMSTART AT_LOGON}.each do |trig_type|
     trigger = {}
     trigger[:trigger_type] = Win32::TaskScheduler.class_eval(trig_type)
     start_end_params(trigger)

--- a/spec/unit/win32/taskscheduler_spec.rb
+++ b/spec/unit/win32/taskscheduler_spec.rb
@@ -72,20 +72,20 @@ RSpec.describe Win32::TaskScheduler, :windows_only do
       end
 
       it "Does not require root to be appended" do
-        task = @test_path + @folder + '\\' + @task
+        task = @test_path + @folder + "\\" + @task
         expect(@ts.exists?(task)).to be_falsey
       end
     end
 
     context "At Nested folder" do
       it "Returns false for non existing folder" do
-        task = folder + '\\' + @task
+        task = folder + "\\" + @task
         expect(@ts.exists?(task)).to be_falsey
       end
 
       it "Returns true for existing folder" do
         @ts = Win32::TaskScheduler.new(@task, @trigger, folder, force)
-        task = @test_path + folder + '\\' + @task
+        task = @test_path + folder + "\\" + @task
         expect(@ts.exists?(task)).to be_truthy
       end
     end

--- a/test/test_taskscheduler.rb
+++ b/test/test_taskscheduler.rb
@@ -601,7 +601,7 @@ class TC_TaskScheduler < Test::Unit::TestCase
 
   test "working_directory= works as expected" do
     setup_task
-    assert_nothing_raised { @ts.working_directory = 'C:\\' }
+    assert_nothing_raised { @ts.working_directory = "C:\\" }
   end
 
   test "working_directory= requires a string argument" do


### PR DESCRIPTION
### Description

This is a reopening of [#85](https://github.com/chef/win32-taskscheduler/pull/85) 

### Issues Resolved

Fixing test breakages and a lint error.

Spellcheck is being removed due to just being copied and pasted from Chef but never set up with a separate dictionary.

### Check List

- [ ] New functionality includes tests
- [X] All tests pass
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
