### PR TITLE
CHEF-24886 - Create CONTRIBUTING.md file with standard template for chef

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,4 @@
 # Contributing to a Progress Chef Infra Client Project
 
-Thank you for your interest in contributing to this project! It is part of the larger Progress Chef Infra Client project. Contribution guidelines can be found at [Contributing to Progress Chef Infra Client](https://github.com/chef/chef-oss-practices/blob/main/projects/chef.md).
+Thank you for your interest in contributing to this project! It is part of the larger Progress Chef Infra Client project. Contribution guidelines can be found at [Contributing to Progress Chef Infra Client](https://chef.github.io/chef-oss-practices/projects/chef/contributing/)
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+# Contributing to a Progress Chef Infra Client Project
+
+Thank you for your interest in contributing to this project! It is part of the larger Progress Chef Infra Client project. Contribution guidelines can be found at [Contributing to Progress Chef Infra Client](https://github.com/chef/chef-oss-practices/blob/main/projects/chef.md).


### PR DESCRIPTION
Create CONTRIBUTING.md file with standard template for chef

This pull request creates the CONTRIBUTING.md file with the standard template for the chef project. As part of the [repo standardization effort](https://github.com/chef-boneyard/oss-repo-standardization-2025) we are replacing all the different contributing guides with a standard template that links to a published version of the chef-oss-practices repo.

This PR is intended to be a mere mechanical change, not a change in policy. Watch chef/chef-oss-practices for changes in policy. 

The link provided in the template may not function at the time this PR is opened, in which case this PR is intended to remain in Draft status if the repo permits; in any case it should not be merged until the link is live.