### PR TITLE
chore: update CODEOWNERS to match win32-certstore

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,4 @@
 # Order is important. The last matching pattern has the most precedence.
 
-*                   @chef/chef-infra-reviewers @chef/chef-infra-approvers @chef/chef-infra-owners
-.expeditor/**       @chef/infra-packages
-*.md                @chef/docs-team
+*            @chef/chef-infra-reviewers @chef/chef-infra-approvers @chef/chef-infra-owners @jaymzh
+.expeditor/  @chef/build-engineering-systems-team


### PR DESCRIPTION
## Description
Updates .github/CODEOWNERS to match the format/ownership used in chef/win32-certstore.

## Changes Made
- Moved CODEOWNERS from root to .github/ convention (kept at existing path)
- Added @jaymzh as an owner for all files
- Changed .expeditor/ owner to @chef/build-engineering-systems-team`n- Removed *.md doc-team specific rule to align with win32-certstore's simpler ruleset