### PR TITLE
docs: add red-green TDD workflow guidance to Copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -510,3 +510,13 @@ All AI-assisted work must be traceable through:
 ---
 
 This comprehensive guide ensures consistent, high-quality development practices while maintaining the repository's standards and Chef's development workflow requirements.
+
+## Red-Green Test-Driven Development
+
+When making code changes in this repository, follow a red-green TDD workflow:
+
+1. **Red**: Write or update a test that captures the desired behavior or reproduces the bug. Run the test (locally or let CI run it) and confirm it **fails**.
+2. **Green**: Write the minimal code change needed to make the failing test pass. Re-run the test (locally or in CI) and confirm it now **passes**.
+3. **Refactor**: With the passing test as a safety net, clean up the implementation as needed, re-running tests to ensure they remain green.
+
+Do not write the fix before the failing test exists. This ensures every change is backed by a test that would have caught the issue, and that the fix is verifiably correct.


### PR DESCRIPTION
## Summary

Adds guidance to the Copilot instructions to follow a red-green TDD workflow: write a test that fails (red), then write the minimal code to make it pass (green), then refactor.

This is a documentation-only change to .github/copilot-instructions.md.